### PR TITLE
Fix build deps for Nix flake on macOS

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -34,9 +34,12 @@
             pkgs.fontconfig
             pkgs.lato
             pkgs.texlivePackages.lato
+            pkgs.curl
           ] ++ lib.optionals pkgs.stdenv.isDarwin (
             with pkgs.darwin.apple_sdk.frameworks; [
               IOKit
+              ApplicationServices
+              Cocoa
             ]
           );
         };


### PR DESCRIPTION
Otherwise the following errors occur at compile time when compiling tectonic_xetex_layout:

	   Compiling tectonic_xetex_layout v0.2.4
	[...]

	The following warnings were emitted during compilation:

	warning: tectonic_xetex_layout@0.2.4: In file included from layout/xetex-XeTeXFontInst.cpp:42:
	warning: tectonic_xetex_layout@0.2.4: layout/tectonic_xetex_layout.h:49:10: fatal error: 'ApplicationServices/ApplicationServices.h' file not found
	warning: tectonic_xetex_layout@0.2.4: #include <ApplicationServices/ApplicationServices.h>
	warning: tectonic_xetex_layout@0.2.4:          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
	warning: tectonic_xetex_layout@0.2.4: 1 error generated.
	warning: tectonic_xetex_layout@0.2.4: ToolExecError: Command env -u IPHONEOS_DEPLOYMENT_TARGET "clang++" "-O0" "-ffunction-sections" "-fdata-sections" "-fPIC" "-gdwarf-2" "-fno-omit-frame-pointer" "--target=arm64-apple-darwin" "-mmacosx-version-min=11.0" "-I" "layout" "-I" "/Users/janis.koenig/.cargo/registry/src/index.crates.io-6f17d22bba15001f/tectonic_bridge_core-0.4.1/support" "-I" "/nix/store/8sy0k9w49vhz7fi6cmw0lkgc9aqhkrfi-harfbuzz-8.4.0-dev/include/harfbuzz" "-I" "/nix/store/lr1fj7ial9j5ngjrklgi7mmbv10w1rl6-freetype-2.13.2-dev/include/freetype2" "-I" "/nix/store/vnsq2kfnma1g5x97f353cjvz1gjspxns-graphite2-1.3.14/include" "-I" "/nix/store/nfj92diqhyswkq9sy7g0kvd6xcqfinnc-icu4c-73.2-dev/include" "-Wall" "-Wextra" "-Wall" "-std=c++14" "-Wall" "-Wdate-time" "-Wendif-labels" "-Wextra" "-Wformat=2" "-Wmissing-declarations" "-Wmissing-include-dirs" "-Wpointer-arith" "-Wredundant-decls" "-Wshadow" "-Wswitch-bool" "-Wundef" "-Wextra-semi" "-Wno-unused-parameter" "-Wno-implicit-fallthrough" "-fno-exceptions" "-fno-rtti" "-DXETEX_MAC=1" "-o" "/Users/janis.koenig/Documents/Development/sbgg/target/debug/build/tectonic_xetex_layout-d9898cfc058f1e65/out/b3219800bda33a1f-xetex-XeTeXFontInst.o" "-c" "layout/xetex-XeTeXFontInst.cpp" with args clang++ did not execute successfully (status code exit status: 1).cargo:warning=In file included from layout/xetex-XeTeXFontMgr.cpp:33:

	[...]

	warning: tectonic_xetex_layout@0.2.4: layout/xetex-XeTeXLayoutInterface.cpp:1135:12: warning: returning address of local temporary object [-Wreturn-stack-address]
	warning: tectonic_xetex_layout@0.2.4:     return XeTeXFontMgr::GetFontManager()->getPlatformFontDesc(fontRef).c_str();
	warning: tectonic_xetex_layout@0.2.4:            ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
	warning: tectonic_xetex_layout@0.2.4: layout/xetex-XeTeXFontMgr_Mac.mm:37:10: fatal error: 'Cocoa/Cocoa.h' file not found
	warning: tectonic_xetex_layout@0.2.4: #include <Cocoa/Cocoa.h>
	warning: tectonic_xetex_layout@0.2.4:          ^~~~~~~~~~~~~~~
	warning: tectonic_xetex_layout@0.2.4: 1 error generated.
	warning: tectonic_xetex_layout@0.2.4: ToolExecError: Command env -u IPHONEOS_DEPLOYMENT_TARGET "clang++" "-O0" "-ffunction-sections" "-fdata-sections" "-fPIC" "-gdwarf-2" "-fno-omit-frame-pointer" "--target=arm64-apple-darwin" "-mmacosx-version-min=11.0" "-I" "layout" "-I" "/Users/janis.koenig/.cargo/registry/src/index.crates.io-6f17d22bba15001f/tectonic_bridge_core-0.4.1/support" "-I" "/nix/store/8sy0k9w49vhz7fi6cmw0lkgc9aqhkrfi-harfbuzz-8.4.0-dev/include/harfbuzz" "-I" "/nix/store/lr1fj7ial9j5ngjrklgi7mmbv10w1rl6-freetype-2.13.2-dev/include/freetype2" "-I" "/nix/store/vnsq2kfnma1g5x97f353cjvz1gjspxns-graphite2-1.3.14/include" "-I" "/nix/store/nfj92diqhyswkq9sy7g0kvd6xcqfinnc-icu4c-73.2-dev/include" "-Wall" "-Wextra" "-Wall" "-std=c++14" "-Wall" "-Wdate-time" "-Wendif-labels" "-Wextra" "-Wformat=2" "-Wmissing-declarations" "-Wmissing-include-dirs" "-Wpointer-arith" "-Wredundant-decls" "-Wshadow" "-Wswitch-bool" "-Wundef" "-Wextra-semi" "-Wno-unused-parameter" "-Wno-implicit-fallthrough" "-fno-exceptions" "-fno-rtti" "-DXETEX_MAC=1" "-o" "/Users/janis.koenig/Documents/Development/sbgg/target/debug/build/tectonic_xetex_layout-d9898cfc058f1e65/out/b3219800bda33a1f-xetex-XeTeXFontMgr_Mac.o" "-c" "layout/xetex-XeTeXFontMgr_Mac.mm" with args clang++ did not execute successfully (status code exit status: 1).cargo:warning=1 warning generated.

	error: failed to run custom build command for `tectonic_xetex_layout v0.2.4`

	error: linking with `cc` failed: exit status: 1
	  |
	  = note: env -u [...]
	  = note: ld: library not found for -lcurl
	          clang-16: error: linker command failed with exit code 1 (use -v to see invocation)